### PR TITLE
Make the package compatible with django 2.x. 

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -4,7 +4,11 @@ Debug Panel middleware
 import threading
 import time
 
-from django.core.urlresolvers import reverse, resolve, Resolver404
+try:
+    from django.core.urlresolvers import reverse, resolve, Resolver404
+except ImportError:
+    from django.urls import reverse, resolve, Resolver404
+
 from django.conf import settings
 from debug_panel.cache import cache
 import debug_toolbar.middleware


### PR DESCRIPTION
The incompatibility was caused by deletion of the`django.core.urlresolvers` module.

https://docs.djangoproject.com/en/2.0/releases/2.0/
```
The django.core.urlresolvers module is removed in favor of its new location, django.urls.
```
